### PR TITLE
Update to composer/installers 2 and streamline the drush command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,6 @@ This Quicksilver project is used for automation of post-deployment tasks on Pant
 
 This project is designed to be included from a site's `composer.json` file, and placed in its appropriate installation directory by [Composer Installers](https://github.com/composer/installers). 
 
-It is defined as a quicksilver script, which means composer should install it in `web/private/scripts/quicksilver/{$name}` by default.
-
-You can override this by adding an installer-paths configuration, for example:
-
-```json
-{
-  "extra": {
-    "installer-paths": {
-      "docroot/private/scripts/pantheonscripts/{$name}/": ["type:quicksilver-script"]
-    }
-  }
-}
-```
-
 The project can be included by using the command:
 
 `composer require kalamuna/quicksilver-deploy-tools`

--- a/README.md
+++ b/README.md
@@ -6,19 +6,15 @@ This Quicksilver project is used for automation of post-deployment tasks on Pant
 
 This project is designed to be included from a site's `composer.json` file, and placed in its appropriate installation directory by [Composer Installers](https://github.com/composer/installers). 
 
-It has to also include custom quick-silver installer as composer installer doesn't support the quicksilver-script type.
+It is defined as a quicksilver script, which means composer should install it in `web/private/scripts/quicksilver/{$name}` by default.
 
-In order for this to work, you should have the following in your composer.json file:
+You can override this by adding an installer-paths configuration, for example:
 
 ```json
 {
-  "require": {
-    "composer/installers": "^1.0.20",
-    "rvtraveller/qs-composer-installer": "1.0"
-  },
   "extra": {
     "installer-paths": {
-      "web/private/scripts/quicksilver/{$name}/": ["type:quicksilver-script"]
+      "docroot/private/scripts/pantheonscripts/{$name}/": ["type:quicksilver-script"]
     }
   }
 }
@@ -38,6 +34,11 @@ Here's an example of what your `pantheon.yml` would look like if this were the o
 api_version: 1
 
 workflows:
+  deploy:
+    after:
+      - type: webphp
+        description: Import configuration from .yml files
+        script: private/scripts/quicksilver/quicksilver-deploy-tools/postdeploy.php
   sync_code:
     after:
       - type: webphp

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Runs postedployment commands such as clear cache and configuration import.",
   "type": "quicksilver-script",
   "require": {
-    "composer/installers": "^2"
+    "composer/installers": "^2.0.1"
   },
   "license": "MIT"
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
   "description": "Runs postedployment commands such as clear cache and configuration import.",
   "type": "quicksilver-script",
   "require": {
-    "composer/installers": "~1.0",
-    "rvtraveller/qs-composer-installer": "~1.0"
+    "composer/installers": "^2"
   },
   "license": "MIT"
 }

--- a/postdeploy.php
+++ b/postdeploy.php
@@ -1,17 +1,2 @@
 <?php
-//Clear all cache
-echo "Rebuilding cache.\n";
-passthru('drush cr');
-echo "Rebuilding cache complete.\n";
-//DB Update
-echo "Updating db.\n";
-passthru('drush updb -y');
-echo "Updating db complete.\n";
-// Import all config changes.
-echo "Importing configuration from yml files...\n";
-passthru('drush config-import -y');
-echo "Import of configuration complete.\n";
-//Clear all cache
-echo "Rebuilding cache.\n";
-passthru('drush cr');
-echo "Rebuilding cache complete.\n";
+passthru('drush deploy');


### PR DESCRIPTION
This appears to work:

`ddev composer require kalamuna/quicksilver-deploy-tools:dev-update-dependencies#99a3dce0cd97037932d15c26973aaa28ee8ddc4c` gives me this:

![CleanShot 2024-06-26 at 14 42 29@2x](https://github.com/kalamuna/quicksilver-deploy-tools/assets/53239/4e7b773c-6058-4add-8567-6b0820d69ca9)

postdeploy.php contains the new abbreviated version of the script.
